### PR TITLE
Increases Usable Module ID's, Customization ID's, COS ID's, and Item ID's

### DIFF
--- a/DxvaTableManager/App.config
+++ b/DxvaTableManager/App.config
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/DxvaTableManager/Code.cs
+++ b/DxvaTableManager/Code.cs
@@ -351,7 +351,7 @@ public class Code
         dummyEntry.shop_price = "0";
         dummyEntry.attr = Attr.Default_N;
         dummyEntry.ng = false;
-        dummyEntry.sort_index = 999;
+        dummyEntry.sort_index = 800;
         Modules.Insert(index ,dummyEntry);
     }
     public static void addDummyEntryCstm(int index)

--- a/DxvaTableManager/DxvaTableManager.csproj
+++ b/DxvaTableManager/DxvaTableManager.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>DivaTableManager</RootNamespace>
     <AssemblyName>DivaTableManager</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
@@ -27,6 +27,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>x64</PlatformTarget>
@@ -69,7 +70,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MikuMikuLibrary">
-      <HintPath>..\..\..\..\Documents\MikuMikuModel\MikuMikuLibrary.dll</HintPath>
+      <HintPath>..\References\MikuMikuLibrary.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/DxvaTableManager/Form1.Designer.cs
+++ b/DxvaTableManager/Form1.Designer.cs
@@ -214,7 +214,7 @@ namespace DxvaTableManager
             // 
             this.idUpDown.Location = new System.Drawing.Point(6, 109);
             this.idUpDown.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});
@@ -506,7 +506,7 @@ namespace DxvaTableManager
             // 
             this.numericUpDown3.Location = new System.Drawing.Point(6, 22);
             this.numericUpDown3.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});
@@ -563,7 +563,7 @@ namespace DxvaTableManager
             // 
             this.numericUpDown2.Location = new System.Drawing.Point(6, 81);
             this.numericUpDown2.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});

--- a/DxvaTableManager/Form1.Designer.cs
+++ b/DxvaTableManager/Form1.Designer.cs
@@ -178,7 +178,7 @@ namespace DxvaTableManager
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Module Properties";
             // 
-            // indexTextBox
+            // indexTextBox: Sort Index
             // 
             this.indexTextBox.Location = new System.Drawing.Point(6, 192);
             this.indexTextBox.Maximum = new decimal(new int[] {
@@ -210,11 +210,11 @@ namespace DxvaTableManager
             this.modCount.TabIndex = 29;
             this.modCount.Text = "Modules:";
             // 
-            // idUpDown
+            // idUpDown: Module ID
             // 
             this.idUpDown.Location = new System.Drawing.Point(6, 109);
             this.idUpDown.Maximum = new decimal(new int[] {
-            4999,
+            5000,
             0,
             0,
             0});
@@ -454,11 +454,11 @@ namespace DxvaTableManager
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Customise Item Properties";
             // 
-            // numericUpDown4
+            // numericUpDown4: Object ID
             // 
             this.numericUpDown4.Location = new System.Drawing.Point(6, 133);
             this.numericUpDown4.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});
@@ -502,7 +502,7 @@ namespace DxvaTableManager
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.button3_Click);
             // 
-            // numericUpDown3
+            // numericUpDown3: Customization Bind Module
             // 
             this.numericUpDown3.Location = new System.Drawing.Point(6, 22);
             this.numericUpDown3.Maximum = new decimal(new int[] {
@@ -532,7 +532,7 @@ namespace DxvaTableManager
             this.checkBox2.UseVisualStyleBackColor = true;
             this.checkBox2.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
             // 
-            // numericUpDown1
+            // numericUpDown1: Customization Sort Index
             // 
             this.numericUpDown1.Location = new System.Drawing.Point(6, 214);
             this.numericUpDown1.Maximum = new decimal(new int[] {
@@ -559,7 +559,7 @@ namespace DxvaTableManager
             this.label1.TabIndex = 29;
             this.label1.Text = "Items:";
             // 
-            // numericUpDown2
+            // numericUpDown2: Customization ID
             // 
             this.numericUpDown2.Location = new System.Drawing.Point(6, 81);
             this.numericUpDown2.Maximum = new decimal(new int[] {

--- a/DxvaTableManager/Form1.resx
+++ b/DxvaTableManager/Form1.resx
@@ -125,26 +125,27 @@ The ID detector will show when you are changing the ID to help you
 choose an unused one.</value>
   </data>
   <data name="label4.ToolTip" xml:space="preserve">
-    <value>The placement of the module in the shop list.
-The list is in ascending order. (0 to 100, etc.)
-You may use clashing numbers although it may cause
-unwanted sorting results.
+    <value>The placement of the customization item in the shop list.
+The list is in ascending order. (0 --&gt; 100, etc.)
+You may use clashing numbers, but when you do, the game will default to sorting by the ID. 
 Sort Index numbers vary by 'Character' setting so 0 for MIKU
 will not impact 0 for SAKINE, for example.</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>152, 17</value>
-  </metadata>
+  </data>
   <data name="label6.ToolTip" xml:space="preserve">
-    <value>The name of the module.
-This is the name that will appear in module select.
+    <value>The name of the customization item.
+When you're playing in Japanese, this will always be the name that is loaded for the customization item.
+This cannot be overriden by mod_str_array.toml; therefore, the name here should always be in Japanese.
 Bare in mind unsupported character sets will not display correctly in-game.
 Please note that you must press the ENTER key to save the name.</value>
   </data>
   <data name="label7.ToolTip" xml:space="preserve">
-    <value>The ID used for this module.
+    <value>The ID used for this customization item.
 This ID will be used when loading module select preview images.
-Please avoid using the same ID for multiple modules.
+Please avoid using the same ID for multiple customization items.
 The ID detector will show when you are changing the ID to help you
 choose an unused one.</value>
   </data>
@@ -154,20 +155,17 @@ The 'Character' set in the box above will control which xxxitm_tbl.txt the COS_X
 (For Example: Setting Character to MIKU will load the COS_XXX from mikitm_tbl.txt)
 Please make sure you have a matching COS entry in the Character Item Table before setting this value.</value>
   </data>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>152, 17</value>
-  </metadata>
   <data name="IndexLabel.ToolTip" xml:space="preserve">
     <value>The placement of the module in the shop list.
 The list is in ascending order. (0 --&gt; 100, etc.)
-You may use clashing numbers although it may cause
-unwanted sorting results.
+You may use clashing numbers, but when you do, the game will default to sorting by the ID. 
 Sort Index numbers vary by 'Character' setting so 0 for MIKU
 will not impact 0 for SAKINE, for example.</value>
   </data>
   <data name="NameLabel.ToolTip" xml:space="preserve">
     <value>The name of the module.
-This is the name that will appear in module select.
+When you're playing in Japanese, this will always be the name that is loaded for the module.
+This cannot be overriden by mod_str_array.toml; therefore, the name here should always be in Japanese.
 Bare in mind unsupported character sets will not display correctly in-game.
 Please note that you must press the ENTER key to save the name.</value>
   </data>
@@ -182,12 +180,12 @@ choose an unused one.</value>
     <value>The COS_XXX to be used for this module.
 The 'Character' set in the box above will control which xxxitm_tbl.txt the COS_XXX is read from.
 (For Example: Setting Character to MIKU will load the COS_XXX from mikitm_tbl.txt)
-Please make sure you have a matching COS entry in the Character Item Table before setting this value.</value>
+Please make sure you have a matching COS entry in the Character Item Table before setting this value.
+Keep in mind that COS entries in the module table is one more than the entry in the xxxitm_tbl.txt; for example, COS_350 in the xxxitm_tbl.txt would be COS_351 in the module table.</value>
   </data>
-  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <data name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing">
     <value>17, 17</value>
-  </metadata>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         AAABAAYAAAAAAAEAIABYPAAAZgAAAICAAAABACAAKAgBAL48AABAQAAAAQAgAChCAADmRAEAMDAAAAEA

--- a/DxvaTableManager/MultiSelect.Designer.cs
+++ b/DxvaTableManager/MultiSelect.Designer.cs
@@ -52,7 +52,7 @@ namespace DxvaTableManager
             // 
             this.numericUpDown1.Location = new System.Drawing.Point(12, 29);
             this.numericUpDown1.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});

--- a/DxvaTableManager/Properties/Resources.Designer.cs
+++ b/DxvaTableManager/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace DxvaTableManager.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/DxvaTableManager/Properties/Settings.Designer.cs
+++ b/DxvaTableManager/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace DxvaTableManager.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.10.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/DxvaTableManager/chritm.Designer.cs
+++ b/DxvaTableManager/chritm.Designer.cs
@@ -359,11 +359,11 @@ namespace DxvaTableManager
             this.groupBox7.TabStop = false;
             this.groupBox7.Text = "No.";
             // 
-            // numericUpDown2
+            // numericUpDown2: Item Number
             // 
             this.numericUpDown2.Location = new System.Drawing.Point(6, 21);
             this.numericUpDown2.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});
@@ -626,11 +626,11 @@ namespace DxvaTableManager
             this.label4.TabIndex = 10;
             this.label4.Text = "Available Items:";
             // 
-            // numericUpDown3
+            // numericUpDown3: COS ID
             // 
             this.numericUpDown3.Location = new System.Drawing.Point(200, 38);
             this.numericUpDown3.Maximum = new decimal(new int[] {
-            5000,
+            2147483647,
             0,
             0,
             0});

--- a/DxvaTableManager/chritm.Designer.cs
+++ b/DxvaTableManager/chritm.Designer.cs
@@ -97,6 +97,7 @@ namespace DxvaTableManager
             this.handsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.contactLensesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.eyeTextureSwapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.customHeadToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.multiDeleteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.chrSel = new System.Windows.Forms.ComboBox();
@@ -247,7 +248,7 @@ namespace DxvaTableManager
             this.attrBox.Name = "attrBox";
             this.attrBox.Size = new System.Drawing.Size(92, 24);
             this.attrBox.TabIndex = 13;
-            this.toolTip1.SetToolTip(this.attrBox, "1 - No Texture Swaps\r\n5 - Has Texture Swaps\r\n37 - Eye/Face Texture Swaps\r\n2085 - " +
+            this.toolTip1.SetToolTip(this.attrBox, "1 - No Texture Swaps\r\n5 - Has Texture Swaps\r\n37 - Eye/Face Texture Swaps\r\n2085 - Custom Head Model" +
         "Head Swaps");
             this.attrBox.SelectedIndexChanged += new System.EventHandler(this.attrBox_SelectedIndexChanged);
             // 
@@ -779,7 +780,8 @@ namespace DxvaTableManager
             this.bodyToolStripMenuItem,
             this.handsToolStripMenuItem,
             this.contactLensesToolStripMenuItem,
-            this.eyeTextureSwapToolStripMenuItem});
+            this.eyeTextureSwapToolStripMenuItem,
+            this.customHeadToolStripMenuItem});
             this.itemPresetsToolStripMenuItem.Name = "itemPresetsToolStripMenuItem";
             this.itemPresetsToolStripMenuItem.Size = new System.Drawing.Size(103, 24);
             this.itemPresetsToolStripMenuItem.Text = "Item Presets";
@@ -846,6 +848,13 @@ namespace DxvaTableManager
             this.eyeTextureSwapToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
             this.eyeTextureSwapToolStripMenuItem.Text = "Eye Texture Swap";
             this.eyeTextureSwapToolStripMenuItem.Click += new System.EventHandler(this.eyeTextureSwapToolStripMenuItem_Click);
+            // 
+            // customHeadToolStripMenuItem
+            // 
+            this.customHeadToolStripMenuItem.Name = "customHeadToolStripMenuItem";
+            this.customHeadToolStripMenuItem.Size = new System.Drawing.Size(224, 26);
+            this.customHeadToolStripMenuItem.Text = "Custom Head Model";
+            this.customHeadToolStripMenuItem.Click += new System.EventHandler(this.customHeadToolStripMenuItem_Click);
             // 
             // multiDeleteToolStripMenuItem
             // 
@@ -1000,6 +1009,7 @@ namespace DxvaTableManager
         private System.Windows.Forms.ToolStripMenuItem handsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem contactLensesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem eyeTextureSwapToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem customHeadToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem deleteShortcutToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem multiDeleteToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem generateObjectDatabaseToolStripMenuItem;

--- a/DxvaTableManager/chritm.cs
+++ b/DxvaTableManager/chritm.cs
@@ -513,7 +513,7 @@ namespace DxvaTableManager
             item.type = 0;
             item.desID = 0;
             item.face_depth = 0;
-            item.uid = "ENTER UID HERE";
+            item.uid = "ENTERUIDHERE";
             item.rpk = -1;
             item.objset.Add("tempitm001");
             KeyValuePair<string, chritmFile> found = Code.chritms.ElementAt(chrSel.SelectedIndex);
@@ -658,6 +658,19 @@ namespace DxvaTableManager
             curItem.flag = 0;
             curItem.attr = 1;
             curItem.type = 0;
+            curItem.orgItm = 0;
+            curItem.face_depth = 0;
+            updateItem();
+        }
+
+        private void customHeadToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            curItem.subID = 24;
+            curItem.desID = 0;
+            curItem.rpk = 1;
+            curItem.uid = "ENTERUIDHERE";
+            curItem.attr = 2085;
+            curItem.type = 1;
             curItem.orgItm = 0;
             curItem.face_depth = 0;
             updateItem();


### PR DESCRIPTION
Increases the Module ID, Customization ID, COS ID, and Item ID maximum values up to the 32 bit integer limit values to prevent unhanded exception errors so that users can freely avoid conflicts without extracting and editing the databases manually. In turn this also fixes the issue where if you opened a manually edited database with ID's above the limit, it would give you an unhanded exception and any related data fields would become uneditable. Since a module ID patch is now publicly available and the new maximum ID's are "seemingly infinite," this will be a great update for the community.